### PR TITLE
chore: Change package ecosystem from 'pip' to 'uv'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
See https://github.com/Matatika/tap-everflow/pull/34