### PR TITLE
fix: Handle no value for integer primary key properties

### DIFF
--- a/tap_bing_ads/client.py
+++ b/tap_bing_ads/client.py
@@ -218,6 +218,9 @@ class BingAdsStream(RESTStream):
             return value
 
         if value == "":
+            if breadcrumb in self.integer_property_breadcrumbs:
+                value = 0
+
             return value if "__".join(breadcrumb) in self.primary_keys else None
 
         if breadcrumb in self.integer_property_breadcrumbs:


### PR DESCRIPTION
Discovered after merging #22 where `AssetGroupId` was coming through as `""` (empty string), causing the following error when loading into Snowflake:

```
sqlalchemy.exc.ProgrammingError: (snowflake.connector.errors.ProgrammingError) 100071 (22000): Failed to cast variant value "" to FIXED
```

Fix is to fallback to `0` for integer properties that make up part of the primary key.