### PR TITLE
fix: `ViewThroughConversionsQualified` properties as number type

### DIFF
--- a/tap_bing_ads/streams.py
+++ b/tap_bing_ads/streams.py
@@ -1078,7 +1078,7 @@ class AdGroupDailyPerformanceStream(_DailyPerformanceReportStream):
         th.Property("VideoViewsAt50Percent", th.IntegerType),
         th.Property("VideoViewsAt75Percent", th.IntegerType),
         th.Property("ViewThroughConversions", th.IntegerType),
-        th.Property("ViewThroughConversionsQualified", th.IntegerType),
+        th.Property("ViewThroughConversionsQualified", th.NumberType),
         th.Property("ViewThroughRate", th.NumberType),
         th.Property("ViewThroughRevenue", th.NumberType),
     ).to_dict()
@@ -1230,7 +1230,7 @@ class AdDailyPerformanceStream(_DailyPerformanceReportStream):
         th.Property("VideoViewsAt50Percent", th.IntegerType),
         th.Property("VideoViewsAt75Percent", th.IntegerType),
         th.Property("ViewThroughConversions", th.IntegerType),
-        th.Property("ViewThroughConversionsQualified", th.IntegerType),
+        th.Property("ViewThroughConversionsQualified", th.NumberType),
         th.Property("ViewThroughRate", th.NumberType),
         th.Property("ViewThroughRevenue", th.NumberType),
     ).to_dict()
@@ -1323,7 +1323,7 @@ class KeywordDailyPerformanceStream(_DailyPerformanceReportStream):
         th.Property("TopVsOther", th.StringType),
         th.Property("TrackingTemplate", th.StringType),
         th.Property("ViewThroughConversions", th.IntegerType),
-        th.Property("ViewThroughConversionsQualified", th.IntegerType),
+        th.Property("ViewThroughConversionsQualified", th.NumberType),
         th.Property("ViewThroughRevenue", th.NumberType),
     ).to_dict()
 
@@ -1441,7 +1441,7 @@ class PublisherUsageDailyPerformanceStream(_DailyPerformanceReportStream):
         th.Property("TopImpressionRatePercent", th.NumberType),
         th.Property("TopVsOther", th.StringType),
         th.Property("ViewThroughConversions", th.IntegerType),
-        th.Property("ViewThroughConversionsQualified", th.IntegerType),
+        th.Property("ViewThroughConversionsQualified", th.NumberType),
         th.Property("ViewThroughRevenue", th.NumberType),
     ).to_dict()
 


### PR DESCRIPTION
Fixes the error `ValueError: invalid literal for int() with base 10: '0.00'`, when trying to cast to `int`.

> You should expect the data type as double whether or not there are partial externally attributed offline conversions.

https://learn.microsoft.com/en-us/advertising/reporting-service/adperformancereportcolumn?view=bingads-13#viewthroughconversionsqualified