### PR TITLE
fix: Handle empty values for `number` properties

### DIFF
--- a/tap_bing_ads/client.py
+++ b/tap_bing_ads/client.py
@@ -220,6 +220,8 @@ class BingAdsStream(RESTStream):
         if value == "":
             if breadcrumb in self.integer_property_breadcrumbs:
                 value = 0
+            elif breadcrumb in self.number_property_breadcrumbs:
+                value = 0.0
 
             return value if "__".join(breadcrumb) in self.primary_keys else None
 


### PR DESCRIPTION
Bing ads have started sending over empty strings instead of nulls. This was handled in integer type column, the sane fix has been extended to number type columns